### PR TITLE
Nested routes bug

### DIFF
--- a/packages/rogue-cli/bundle/templates/server.js
+++ b/packages/rogue-cli/bundle/templates/server.js
@@ -4,7 +4,7 @@ import serveStatic from 'serve-static'
 import App from '<%= appPath %>'
 
 const app = new Rogue(App, {
-  bodyTags: [`<script src="bundle.js" defer></script>`]
+  bodyTags: [`<script src="/bundle.js" defer></script>`]
 })
 
 app.preuse(serveStatic(`.rogue/build/public`))

--- a/packages/rogue-cli/scripts/dev.js
+++ b/packages/rogue-cli/scripts/dev.js
@@ -20,7 +20,9 @@ createBundlers().then(({ clientBundler, serverBundler }) => {
     server = http.createServer(app.render)
 
     server.listen(PORT, error => {
-      if (error) console.log(error)
+      if (error){ console.log(error)} else {
+        console.log(`App starts on port: ${PORT}`)
+      }
     })
   }
 
@@ -37,6 +39,10 @@ createBundlers().then(({ clientBundler, serverBundler }) => {
       await clientBundler.bundle()
       restartApp()
     }
+  })
+
+  clientBundler.on('buildError', (e) => {
+    console.error('Error while building client bundle', e);
   })
 
   bundleApp(clientBundler, serverBundler).then(() => {

--- a/packages/rogue-cli/scripts/dev.js
+++ b/packages/rogue-cli/scripts/dev.js
@@ -20,7 +20,9 @@ createBundlers().then(({ clientBundler, serverBundler }) => {
     server = http.createServer(app.render)
 
     server.listen(PORT, error => {
-      if (error){ console.log(error)} else {
+      if (error){
+        console.log(error)
+      } else {
         console.log(`App starts on port: ${PORT}`)
       }
     })


### PR DESCRIPTION
Currently bundle injects with relative path. So client-side unable to load bundle.js for routes with more then one '/' in path. 